### PR TITLE
fixed reducers to handle related collections

### DIFF
--- a/client/src/App/pages/NewTrip/DestinationsData.js
+++ b/client/src/App/pages/NewTrip/DestinationsData.js
@@ -1,13 +1,12 @@
 import React from 'react';
 
 function DestinationsData(props) {
-    // console.log(props)
     let { destinations } = props;
     return (
         <div className='destinationsData'>
-            {destinations &&
+            {destinations && 
                 destinations.map((dest, i) =>
-                    <div className='destination' key={i}>
+                    <div className='destination' key={dest._id}>
                         <h4>{dest.name}</h4>
                         <div className="trip-list-dates">
                             {dest.startDate && <p>Start Date: {new Date(dest.startDate).toLocaleDateString()}</p>}

--- a/client/src/App/pages/NewTrip/DestinationsData.js
+++ b/client/src/App/pages/NewTrip/DestinationsData.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function DestinationsData(props) {
-    console.log(props)
+    // console.log(props)
     let { destinations } = props;
     return (
         <div className='destinationsData'>

--- a/client/src/App/pages/NewTrip/index.js
+++ b/client/src/App/pages/NewTrip/index.js
@@ -49,8 +49,7 @@ class NewTrip extends Component {
 
     addDestination = (e, dest) => {
         e.preventDefault();
-        this.props.addDestination(dest);
-        this.props.editTrip(dest, this.props.currentTrip._id);
+        this.props.addDestination(dest, this.props.currentTrip._id);
     }
     addTransportation = (e, trans) => {
         e.preventDefault();
@@ -107,7 +106,7 @@ class NewTrip extends Component {
             addingDestination,
             addingTransportation,
             addingAccommodation } = this.state;
-            console.log(this.props)
+            // console.log(this.props)
         return (
             <div className='newTrip'>
 

--- a/client/src/App/pages/NewTrip/index.js
+++ b/client/src/App/pages/NewTrip/index.js
@@ -10,6 +10,8 @@ import AccommodationsData from './AccommodationsData';
 import { connect } from 'react-redux';
 import { addTrip, getTrips, editTrip } from '../../../redux/trips-reducer';
 import { addDestination } from '../../../redux/destinations-reducer';
+import { addTransportation } from '../../../redux/transportations-reducer';
+import { addReservation } from '../../../redux/reservations-reducer';
 
 class NewTrip extends Component {
     constructor(props) {
@@ -36,12 +38,12 @@ class NewTrip extends Component {
     }
 
     handleChange = (e) => {
-        let { name, value } = e.target;
+        let { name, value, type, checked } = e.target;
         this.setState(prevState => {
             return {
                 inputs: {
                     ...prevState.inputs,
-                    [name]: value
+                    [name]: type === "checkbox" ? checked : value
                 }
             }
         })
@@ -49,7 +51,14 @@ class NewTrip extends Component {
 
     addDestination = (e, dest) => {
         e.preventDefault();
-        this.props.addDestination(dest, this.props.currentTrip._id);
+        this.setState(prevState => {
+            return {
+                ...prevState,
+                destinations: [...prevState.inputs.destinations, dest],
+                addingDestination: false
+            }
+        })
+        this.props.addDestination(dest, this.props.trips.currentTrip._id);
     }
     addTransportation = (e, trans) => {
         e.preventDefault();
@@ -60,6 +69,7 @@ class NewTrip extends Component {
                 addingTransportation: false
             }
         })
+        this.props.addTransportation(trans, this.props.destinations.currentDestination._id);
     }
     addAccommodation = (e, accom) => {
         e.preventDefault();
@@ -70,6 +80,7 @@ class NewTrip extends Component {
                 addingAccommodation: false
             }
         })
+        this.props.addReservation(accom, this.props.destinations.currentDestination._id);
     }
     openForm = (e) => {
         switch (e.target.name) {
@@ -127,11 +138,11 @@ class NewTrip extends Component {
                         
                         {/* GEN NEW TRIP DATA */}
 
-                        <NewTripData {...this.props.currentTrip} />
+                        <NewTripData {...this.props.trips.currentTrip} />
 
                         {/* DESTINATIONS DATA */}
 
-                        <DestinationsData {...this.props.currentTrip} />
+                        <DestinationsData destinations={this.props.destinations.data} />
                         
                         {/* ADD DESTINATION FORM/TOGGLE BUTTON */}
                         
@@ -167,4 +178,5 @@ class NewTrip extends Component {
     }
 }
 
-export default connect(state => state.trips, { addTrip, getTrips, editTrip, addDestination })(NewTrip);
+// export default connect(state => state.trips, { addTrip, getTrips, editTrip, addDestination, addTransportation, addReservation })(NewTrip);
+export default connect(state => state, { addTrip, getTrips, editTrip, addDestination, addTransportation, addReservation })(NewTrip);

--- a/client/src/redux/destinations-reducer.js
+++ b/client/src/redux/destinations-reducer.js
@@ -14,6 +14,7 @@ const destinationsURL = "/api/destinations/";
 
 const initialState = {
     data: [],
+    currentDestination: {},
     loading: true,
     errMsg: ""
 }
@@ -159,7 +160,8 @@ const destinationsReducer = (state = initialState, action) => {
             return {
                 ...state,
                 loading: false,
-                data: [...state.data, action.newDestination]
+                data: [...state.data, action.newDestination],
+                currentDestination: action.newDestination
             }
         case EDIT_DESTINATION:
             return {

--- a/client/src/redux/destinations-reducer.js
+++ b/client/src/redux/destinations-reducer.js
@@ -1,11 +1,13 @@
 import axios from 'axios';
 
+import { EDIT_TRIP } from './trips-reducer';
+
 const LOADING = 'LOADING';
 const ERR_MSG = 'ERR_MSG';
 const GET_DESTINATIONS = 'GET_DESTINATIONS';
 const GET_ONE_DESTINATION = 'GET_ONE_DESTINATION';
 const ADD_DESTINATION = 'ADD_DESTINATION';
-const EDIT_DESTINATION = 'EDIT_DESTINATION';
+export const EDIT_DESTINATION = 'EDIT_DESTINATION';
 const DELETE_DESTINATION = 'DELETE_DESTINATION';
 
 const destinationsURL = "/api/destinations/";
@@ -56,14 +58,27 @@ export const getOneDestination = (id) => {
     }
 }
 
-export const addDestination = (newDestination) => {
+export const addDestination = (newDestination, tripID) => {
     return dispatch => {
         axios.post(destinationsURL, newDestination)
             .then(response => {
                 dispatch({
-                    type: 'ADD_DESTINATION',
+                    type: ADD_DESTINATION,
                     newDestination: response.data
                 })
+                const destID = response.data._id;
+                return destID;
+            })
+            .then(destID => {
+                let editedTrip = { destinations: destID };
+                axios.post(`/api/trips/${tripID}/add-destination`, editedTrip)
+                    .then(response => {
+                        dispatch({
+                            type: EDIT_TRIP,
+                            editedTrip: response.data,
+                            tripID
+                        })
+                    })
             })
             .catch(err => {
                 dispatch({
@@ -79,7 +94,7 @@ export const deleteDestination = (id) => {
         axios.delete(destinationsURL + id)
             .then(response => {
                 dispatch({
-                    type: 'DELETE_DESTINATION',
+                    type: DELETE_DESTINATION,
                     id
                 })
             })
@@ -98,7 +113,7 @@ export const editDestination = (editedDestination, id) => {
         axios.put(url, editedDestination)
             .then(response => {
                 dispatch({
-                    type: 'EDIT_DESTINATION',
+                    type: EDIT_DESTINATION,
                     editedDestination: response.data,
                     id
                 })

--- a/client/src/redux/index.js
+++ b/client/src/redux/index.js
@@ -4,15 +4,16 @@ import thunk from "redux-thunk";
 import trips from "./trips-reducer";
 import destinations from "./destinations-reducer";
 import reservations from "./reservations-reducer";
-import transportation from "./transportation-reducer";
+import transportations from "./transportations-reducer";
 import user from "./auth-reducer";
 
-const store = createStore(combineReducers({trips, destinations, reservations, transportation, user}), 
+const store = createStore(combineReducers({trips, destinations, reservations, transportations, user}), 
 window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 applyMiddleware(thunk));
 
 
 store.subscribe(() => {
+    console.log("Redux Store subscription below:")
     console.log(store.getState());
 })
 

--- a/client/src/redux/reservations-reducer.js
+++ b/client/src/redux/reservations-reducer.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { EDIT_DESTINATION } from './destinations-reducer';
+
 const LOADING = 'LOADING';
 const ERR_MSG = 'ERR_MSG';
 const GET_RESERVATIONS = 'GET_RESERVATIONS';
@@ -56,7 +58,7 @@ export const getOneReservation = (id) => {
     }
 }
 
-export const addReservation = (newReservation) => {
+export const addReservation = (newReservation, destID) => {
     return dispatch => {
         axios.post(reservationsURL, newReservation)
             .then(response => {
@@ -64,6 +66,19 @@ export const addReservation = (newReservation) => {
                     type: 'ADD_RESERVATION',
                     newReservation: response.data
                 })
+                const resID = response.data._id;
+                return resID;
+            })
+            .then(resID => {
+                let editedDestination = { reservations: resID };
+                axios.post(`/api/destinations/${destID}/add-reservation`, editedDestination)
+                    .then(response => {
+                        dispatch({
+                            type: EDIT_DESTINATION,
+                            editedDestination: response.data,
+                            destID
+                        })
+                    })
             })
             .catch(err => {
                 dispatch({

--- a/client/src/redux/transportation-reducer.js
+++ b/client/src/redux/transportation-reducer.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { EDIT_DESTINATION } from './destinations-reducer';
+
 const LOADING = 'LOADING';
 const ERR_MSG = 'ERR_MSG';
 const GET_TRANSPORTATION = 'GET_TRANSPORTATION';
@@ -56,14 +58,27 @@ export const getOneTransportation = (id) => {
     }
 }
 
-export const addTransportation = (newTransportation) => {
+export const addTransportation = (newTransportation, destID) => {
     return dispatch => {
         axios.post(transportationURL, newTransportation)
             .then(response => {
                 dispatch({
-                    type: 'ADD_TRANSPORTATION',
+                    type: ADD_TRANSPORTATION,
                     newTransportation: response.data
                 })
+                const transID = response.data._id;
+                return transID;
+            })
+            .then(transID => {
+                let editedDestination = { transportations: transID };
+                axios.post(`/api/destinations/${destID}/add-transportation`, editedDestination)
+                    .then(response => {
+                        dispatch({
+                            type: EDIT_DESTINATION,
+                            editedDestination: response.data,
+                            destID
+                        })
+                    })
             })
             .catch(err => {
                 dispatch({
@@ -79,7 +94,7 @@ export const deleteTransportation = (id) => {
         axios.delete(transportationURL + id)
             .then(response => {
                 dispatch({
-                    type: 'DELETE_TRANSPORTATION',
+                    type: DELETE_TRANSPORTATION,
                     id
                 })
             })
@@ -98,7 +113,7 @@ export const editTransportation = (editedTransportation, id) => {
         axios.put(url, editedTransportation)
             .then(response => {
                 dispatch({
-                    type: 'EDIT_TRANSPORTATION',
+                    type: EDIT_TRANSPORTATION,
                     editedTransportation: response.data,
                     id
                 })

--- a/client/src/redux/transportations-reducer.js
+++ b/client/src/redux/transportations-reducer.js
@@ -4,13 +4,13 @@ import { EDIT_DESTINATION } from './destinations-reducer';
 
 const LOADING = 'LOADING';
 const ERR_MSG = 'ERR_MSG';
-const GET_TRANSPORTATION = 'GET_TRANSPORTATION';
+const GET_TRANSPORTATIONS = 'GET_TRANSPORTATIONS';
 const GET_ONE_TRANSPORTATION = 'GET_ONE_TRANSPORTATION';
 const ADD_TRANSPORTATION = 'ADD_TRANSPORTATION';
 const EDIT_TRANSPORTATION = 'EDIT_TRANSPORTATION';
 const DELETE_TRANSPORTATION = 'DELETE_TRANSPORTATION';
 
-const transportationURL = "/api/transportation/";
+const transportationsURL = "/api/transportations/";
 
 const initialState = {
     data: [],
@@ -24,10 +24,10 @@ const initialState = {
 /////////////////////
 export const getTransportation = () => {
     return dispatch => {
-        axios.get(transportationURL)
+        axios.get(transportationsURL)
             .then(response => {
                 dispatch({
-                    type: GET_TRANSPORTATION,
+                    type: GET_TRANSPORTATIONS,
                     data: response.data
                 })
             })
@@ -42,7 +42,7 @@ export const getTransportation = () => {
 
 export const getOneTransportation = (id) => {
     return dispatch => {
-        axios.get(transportationURL + id)
+        axios.get(transportationsURL + id)
             .then(response => {
                 dispatch({
                     type: GET_ONE_TRANSPORTATION,
@@ -60,7 +60,7 @@ export const getOneTransportation = (id) => {
 
 export const addTransportation = (newTransportation, destID) => {
     return dispatch => {
-        axios.post(transportationURL, newTransportation)
+        axios.post(transportationsURL, newTransportation)
             .then(response => {
                 dispatch({
                     type: ADD_TRANSPORTATION,
@@ -91,7 +91,7 @@ export const addTransportation = (newTransportation, destID) => {
 
 export const deleteTransportation = (id) => {
     return dispatch => {
-        axios.delete(transportationURL + id)
+        axios.delete(transportationsURL + id)
             .then(response => {
                 dispatch({
                     type: DELETE_TRANSPORTATION,
@@ -109,7 +109,7 @@ export const deleteTransportation = (id) => {
 
 export const editTransportation = (editedTransportation, id) => {
     return dispatch => {
-        let url = transportationURL + id;
+        let url = transportationsURL + id;
         axios.put(url, editedTransportation)
             .then(response => {
                 dispatch({
@@ -130,7 +130,7 @@ export const editTransportation = (editedTransportation, id) => {
 /////////////
 // Reducer //
 /////////////
-const transportationReducer = (state = initialState, action) => {
+const transportationsReducer = (state = initialState, action) => {
     switch (action.type) {
         case LOADING:
             return {
@@ -143,7 +143,7 @@ const transportationReducer = (state = initialState, action) => {
                 loading: false,
                 errMsg: action.errMsg
             }
-        case GET_TRANSPORTATION:
+        case GET_TRANSPORTATIONS:
             return {
                 ...state,
                 loading: false,
@@ -183,4 +183,4 @@ const transportationReducer = (state = initialState, action) => {
     }
 }
 
-export default transportationReducer;
+export default transportationsReducer;

--- a/client/src/redux/trips-reducer.js
+++ b/client/src/redux/trips-reducer.js
@@ -5,7 +5,7 @@ const ERR_MSG = 'ERR_MSG';
 const GET_TRIPS = 'GET_TRIPS';
 const GET_ONE_TRIP = 'GET_ONE_TRIP';
 const ADD_TRIP = 'ADD_TRIP';
-const EDIT_TRIP = 'EDIT_TRIP';
+export const EDIT_TRIP = 'EDIT_TRIP';
 const DELETE_TRIP = 'DELETE_TRIP';
 
 const tripsURL = "/api/trips/";
@@ -62,7 +62,7 @@ export const addTrip = (newTrip) => {
         axios.post(tripsURL, newTrip)
             .then(response => {
                 dispatch({
-                    type: 'ADD_TRIP',
+                    type: ADD_TRIP,
                     newTrip: response.data,
                 })
             })
@@ -80,7 +80,7 @@ export const deleteTrip = (id) => {
         axios.delete(tripsURL + id)
             .then(response => {
                 dispatch({
-                    type: 'DELETE_TRIP',
+                    type: DELETE_TRIP,
                     id
                 })
             })
@@ -99,7 +99,7 @@ export const editTrip = (editedTrip, id) => {
         axios.put(url, editedTrip)
             .then(response => {
                 dispatch({
-                    type: 'EDIT_TRIP',
+                    type: EDIT_TRIP,
                     editedTrip: response.data,
                     id
                 })

--- a/models/destination-model.js
+++ b/models/destination-model.js
@@ -27,7 +27,7 @@ const destinationSchema = new Schema({
 
     reservations: [{
         type: Schema.Types.ObjectId,
-        ref: "Reservations"
+        ref: "Reservation"
     }]
 
 

--- a/models/trip-model.js
+++ b/models/trip-model.js
@@ -20,8 +20,12 @@ const tripSchema = new Schema({
     destinations: [{
         type: Schema.Types.ObjectId,
         ref: "Destination"
-    }]
+    }],
 
+    users: [{
+        type: Schema.Types.ObjectId,
+        ref: "User"
+    }]
 
 },{timestamps: true});
 

--- a/models/user-model.js
+++ b/models/user-model.js
@@ -14,14 +14,9 @@ const userSchema = new Schema ({
         type: String,
     },
     isAdmin: {
-        type: boolean,
+        type: Boolean,
         default: false
-    },
-    trips: [{
-        type: Schema.Types.ObjectId,
-        ref: "Trip"
-
-    }]
+    }
 
 },{timestamps: true});
 

--- a/routes/destination-routes.js
+++ b/routes/destination-routes.js
@@ -40,5 +40,23 @@ destinationRouter.route("/:id")
         });
     })
 
+destinationRouter.route("/:id/add-reservation")
+    .post((req, res) => {
+        DestinationModel.findOneAndUpdate({ _id: req.params.id }, { $push: req.body }, { new: true }, (err, updatedDestination) => {
+            if (err) return res.send(err);
+            if (!updatedDestination) return res.status(404).send({ message: `Destination ID ${req.params.id} Not found` });
+            res.status(200).send(updatedDestination);
+        })
+    })
+
+
+destinationRouter.route("/:id/add-transportation")
+    .post((req, res) => {
+        DestinationModel.findOneAndUpdate({ _id: req.params.id }, { $push: req.body }, { new: true }, (err, updatedDestination) => {
+            if (err) return res.send(err);
+            if (!updatedDestination) return res.status(404).send({ message: `Destination ID ${req.params.id} Not found`});
+            res.status(200).send(updatedDestination);
+        })
+    })
 
 module.exports = destinationRouter;

--- a/routes/reservation-routes.js
+++ b/routes/reservation-routes.js
@@ -21,21 +21,21 @@ reservationRouter.route("/:id")
     .get((req, res) => {
        ReservationModel.findOne({ _id: req.params.id }, (err, foundReservation) => {
             if (err) return res.send(err);
-            if (!foundReservation) return res.status(404).send({ message: "Not found" });
+            if (!foundReservation) return res.status(404).send({ message: `Reservation ID ${req.params.id} Not found` });
             res.status(200).send(foundReservation);
         })
     })
     .delete((req, res) => {
        ReservationModel.findOneAndRemove({ _id: req.params.id }, (err, deletedReservation) => {
             if (err) return res.send(err);
-            if (!deletedReservation) return res.status(404).send({ message: "Not found" });
+            if (!deletedReservation) return res.status(404).send({ message: `Reservation ID ${req.params.id} Not found` });
             res.status(200).send(`${deletedReservation.name} was deleted.`);
         })
     })
     .put((req, res) => {
        ReservationModel.findOneAndUpdate({ _id: req.params.id }, req.body, { new: true }, (err, updatedReservation) => {
             if (err) return res.send(err);
-            if (!updatedReservation) return res.status(404).send({ message: "Not found" });
+            if (!updatedReservation) return res.status(404).send({ message: `Reservation ID ${req.params.id} Not found` });
             res.status(200).send(updatedReservation);
         });
     })

--- a/routes/transportation-routes.js
+++ b/routes/transportation-routes.js
@@ -21,21 +21,21 @@ transportationRouter.route('/:id')
     .get((req, res) => {
         TransportationModel.findOne({ _id: req.params.id }, (err, foundTransportation) => {
             if (err) return res.send(err);
-            if (!foundTransportation) return res.status(404).send({ message: "Not found" });
+            if (!foundTransportation) return res.status(404).send({ message: `Transportation ID ${req.params.id} Not found` });
             res.status(200).send(foundTransportation);
         })
     })
     .delete((req, res) => {
         TransportationModel.findOneAndRemove({ _id: req.params.id }, (err, deleteTransportation) => {
             if (err) return res.send(err);
-            if (!deleteTransportation) return res.status(404).send({ message: 'Not found' });
+            if (!deleteTransportation) return res.status(404).send({ message: `Transportation ID ${req.params.id} Not found` });
             res.status(200).send(`${deleteTransportation.name} was deleted.`);
         })
     })
     .put((req, res) => {
         TransportationModel.findOneAndUpdate({ _id: req.params.id }, req.body, { new: true }, (err, updateTransportation) => {
             if (err) return res.send(err);
-            if (!updateTransportation) return res.status(404).send({ message: 'Not found' });
+            if (!updateTransportation) return res.status(404).send({ message: `Transportation ID ${req.params.id} Not found` });
         });
     })
 

--- a/routes/trip-routes.js
+++ b/routes/trip-routes.js
@@ -33,11 +33,19 @@ tripRouter.route("/:id")
         })
     })
     .put((req, res) => {
-        TripModel.findOneAndUpdate({ _id: req.params.id }, req.body, { new: true }, (err, updatedTrip) => {
+        TripModel.findOneAndUpdate({ _id: req.params.id }, req.body, { returnNewDocument: true }, (err, updatedTrip) => {
             if (err) return res.send(err);
             if (!updatedTrip) return res.status(404).send({ message: "Not found" });
             res.status(200).send(updatedTrip);
         });
+    })
+tripRouter.route("/:id/add-destination")
+    .post((req, res) => {
+        TripModel.findOneAndUpdate({ _id: req.params.id }, { $push: req.body }, { new: true }, (err, updatedTrip) => {
+            if (err) return res.send(err);
+            if (!updatedTrip) return res.status(404).send({ message: `${req.params.id} Not found`});
+            res.status(200).send(updatedTrip);
+        })
     })
 
 

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ app.use(express.static(path.join(__dirname, "client", "build")));
 //routes
 app.use("/api/trips", tripRouter);
 app.use("/api/destinations", destinationRouter);
-app.use("/api/transportation", transportationRouter);
+app.use("/api/transportations", transportationRouter);
 app.use("/api/reservations", reservationRouter);
 
 // database


### PR DESCRIPTION
These changes are to implement the things we discussed with Ben regarding saving the "related ID" in a document. The suggestion Ben gave for the server routes didn't work, so those are not included in this commit. I'd like to get those working before we do much more with the New Trip component.